### PR TITLE
Issue 50 mpm event with php5

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,4 @@
 # limitations under the License.
 #
 
-# ::Chef::Node.send(:include, Opscode::OpenSSL::Password)
-
 default['application']['admin']['email']    = 'admin@zf2.example.com'

--- a/recipes/php.rb
+++ b/recipes/php.rb
@@ -7,18 +7,29 @@
 # All rights reserved - Do Not Redistribute
 #
 
+# include_recipe 'zf2::webserver'
 
 # repository is also added to default, because of the issue:
 # installing php5.3 during compiletime. and never installing php5.4
 
 apt_repository 'php-5.4' do
-  uri          'http://ppa.launchpad.net/ondrej/php5-oldstable/ubuntu'
-  distribution node['lsb']['codename']
-  components   ['main']
-  keyserver    'keyserver.ubuntu.com'
-  key          'E5267A6C'
+  uri           'http://ppa.launchpad.net/ondrej/php5-oldstable/ubuntu'
+  distribution  node['lsb']['codename']
+  components    ['main']
+  keyserver     'keyserver.ubuntu.com'
+  key           'E5267A6C'
   only_if { node['php']['set_version'] == '5.4' }
+  action        :add
+end
+
+apt_repository 'php-5.4' do
+  # uri           'http://ppa.launchpad.net/ondrej/php5-oldstable/ubuntu'
+  # distribution  node['lsb']['codename']
+  # components    ['main']
+  # keyserver     'keyserver.ubuntu.com'
+  # key           'E5267A6C'
+  only_if { node['php']['set_version'] != '5.4' }
+  action        :remove
 end
 
 include_recipe 'php'
-

--- a/recipes/servernode.rb
+++ b/recipes/servernode.rb
@@ -21,10 +21,10 @@ include_recipe 'zf2::baseserver'
 
 include_recipe 'zf2::database'
 
+include_recipe 'zf2::webserver'
+
 include_recipe 'zf2::php'
 
 include_recipe 'zf2::nodejs'
 
 include_recipe 'zf2::projects'
-
-include_recipe 'zf2::webserver'


### PR DESCRIPTION
the change in recipes/servernode.rb somehow fixes #50 
i suspect it has something todo with "libapache2-mod-php5"
the apache2 server initially is installed with mpm_event (according chef logs), then after it completed, i checked, it uses mpm_prefork (thus not mpm_event).